### PR TITLE
MOAF-34

### DIFF
--- a/BFWControls/Modules/Carousel/Controller/CarouselViewController.swift
+++ b/BFWControls/Modules/Carousel/Controller/CarouselViewController.swift
@@ -88,7 +88,7 @@ class CarouselViewController: UICollectionViewController {
         return page < 0 || pageCount == 0 ? CGFloat(pageCount) + page : page.truncatingRemainder(dividingBy: CGFloat(pageCount))
     }
     
-    lazy var pageControl: UIPageControl! = {
+    lazy var pageControl: UIPageControl = {
         /* If this carousel is embedded as a container in another view controller, find a page control already
          existing in that view controller, otherwise create a new one.
          */
@@ -188,7 +188,7 @@ class CarouselViewController: UICollectionViewController {
         if collectionViewSize != collectionView?.bounds.size {
             collectionViewSize = collectionView?.bounds.size
             collectionView?.reloadData()
-            scroll(toPage: 0, animated: false)
+            scroll(toPage: pageControl.currentPage, animated: false)
         }
     }
     


### PR DESCRIPTION
Universal App - carouselView always goes back to Optus default landing view when changed orientationMOAF-34
carouselView always goes back to Optus default landing view when changed orientation
. In viewDidLayoutSubviews, change scroll page number to page control current instead of 0
. Remove exclamation mark for property ‘pageControl’