### PR TITLE
Fix/crash will display need refresh dynamic last cell height

### DIFF
--- a/BFWControls/Modules/Table/Controller/StaticTableViewController.swift
+++ b/BFWControls/Modules/Table/Controller/StaticTableViewController.swift
@@ -17,7 +17,7 @@ class StaticTableViewController: UITableViewController {
     @IBInspectable open var intrinsicHeightCells: Bool = false
     
     fileprivate var isDynamicLastCell: Bool = false
-    fileprivate var needRefreshDynamicLastCellHeight: Bool = true
+    fileprivate var needRefreshDynamicLastCellHeight: Bool = false
     fileprivate var dynamicLastCellHeight: CGFloat?
     fileprivate var previousRowFrame = CGRect()
     


### PR DESCRIPTION
Fixed crash issue in `willDisplay:cell:forRowAt` caused by needRefreshDynamicLastCellHeight initially true which has to be set after last cell is visible.