### PR TITLE
Fix/carosel view change orientation

### DIFF
--- a/BFWControls/Modules/Carousel/Controller/CarouselViewController.swift
+++ b/BFWControls/Modules/Carousel/Controller/CarouselViewController.swift
@@ -188,7 +188,7 @@ open class CarouselViewController: UICollectionViewController {
         if collectionViewSize != collectionView?.bounds.size {
             collectionViewSize = collectionView?.bounds.size
             collectionView?.reloadData()
-            scroll(toPage: 0, animated: false)
+            scroll(toPage: pageControl.currentPage, animated: false)
         }
     }
     


### PR DESCRIPTION
MOAF-34
iOS - Universal App - carouselView always goes back to Optus default landing view when changed orientation

yesterday's change was overrided. commit again