### PR TITLE
Feature/moaf 34 update pagecontrol

### DIFF
--- a/BFWControls/Modules/Carousel/Controller/CarouselViewController.swift
+++ b/BFWControls/Modules/Carousel/Controller/CarouselViewController.swift
@@ -234,7 +234,18 @@ extension CarouselViewController {
     
     open override func scrollViewDidScroll(_ scrollView: UIScrollView) {
         if scrollView == collectionView {
-            updatePageControl()
+            if let collectionViewSize = collectionViewSize {
+                if pageControl.superview == collectionView {
+                    pageControl.frame.origin.x = (collectionViewSize.width - pageControl.frame.width) / 2 + collectionView!.contentOffset.x
+                    pageControl.frame.origin.y = collectionViewSize.height - pageControl.frame.height + collectionView!.contentOffset.y - controlInsetBottom
+                }
+                pageControl.numberOfPages = pageCount
+            }
+            if let size = collectionViewSize,
+                size == scrollView.frame.size
+            {
+                pageControl.currentPage = currentPage
+            }
         }
     }
     

--- a/BFWControls/Modules/Carousel/Controller/CarouselViewController.swift
+++ b/BFWControls/Modules/Carousel/Controller/CarouselViewController.swift
@@ -129,14 +129,16 @@ open class CarouselViewController: UICollectionViewController {
         scroll(toPage: pageControl.currentPage, animated: true)
     }
     
-    fileprivate func updatePageControl() {
+    fileprivate func updatePageControl(_ shouldUpdateCurrentPage: Bool = true) {
         if let collectionViewSize = collectionViewSize {
             if pageControl.superview == collectionView {
                 pageControl.frame.origin.x = (collectionViewSize.width - pageControl.frame.width) / 2 + collectionView!.contentOffset.x
                 pageControl.frame.origin.y = collectionViewSize.height - pageControl.frame.height + collectionView!.contentOffset.y - controlInsetBottom
             }
             pageControl.numberOfPages = pageCount
-            pageControl.currentPage = currentPage
+            if shouldUpdateCurrentPage {
+                pageControl.currentPage = currentPage
+            }
         }
     }
     
@@ -234,18 +236,7 @@ extension CarouselViewController {
     
     open override func scrollViewDidScroll(_ scrollView: UIScrollView) {
         if scrollView == collectionView {
-            if let collectionViewSize = collectionViewSize {
-                if pageControl.superview == collectionView {
-                    pageControl.frame.origin.x = (collectionViewSize.width - pageControl.frame.width) / 2 + collectionView!.contentOffset.x
-                    pageControl.frame.origin.y = collectionViewSize.height - pageControl.frame.height + collectionView!.contentOffset.y - controlInsetBottom
-                }
-                pageControl.numberOfPages = pageCount
-            }
-            if let size = collectionViewSize,
-                size == scrollView.frame.size
-            {
-                pageControl.currentPage = currentPage
-            }
+            updatePageControl(collectionViewSize ?? CGSize() == scrollView.frame.size)
         }
     }
     

--- a/BFWControls/Modules/Carousel/Controller/CarouselViewController.swift
+++ b/BFWControls/Modules/Carousel/Controller/CarouselViewController.swift
@@ -129,7 +129,7 @@ open class CarouselViewController: UICollectionViewController {
         scroll(toPage: pageControl.currentPage, animated: true)
     }
     
-    fileprivate func updatePageControl(_ shouldUpdateCurrentPage: Bool = true) {
+    fileprivate func updatePageControl(shouldUpdateCurrentPage: Bool = true) {
         if let collectionViewSize = collectionViewSize {
             if pageControl.superview == collectionView {
                 pageControl.frame.origin.x = (collectionViewSize.width - pageControl.frame.width) / 2 + collectionView!.contentOffset.x
@@ -236,7 +236,7 @@ extension CarouselViewController {
     
     open override func scrollViewDidScroll(_ scrollView: UIScrollView) {
         if scrollView == collectionView {
-            updatePageControl(collectionViewSize ?? CGSize() == scrollView.frame.size)
+            updatePageControl(shouldUpdateCurrentPage: collectionViewSize ?? CGSize.zero == scrollView.frame.size)
         }
     }
     

--- a/BFWControls/Modules/Carousel/Controller/CarouselViewController.swift
+++ b/BFWControls/Modules/Carousel/Controller/CarouselViewController.swift
@@ -236,7 +236,7 @@ extension CarouselViewController {
     
     open override func scrollViewDidScroll(_ scrollView: UIScrollView) {
         if scrollView == collectionView {
-            updatePageControl(shouldUpdateCurrentPage: collectionViewSize ?? CGSize.zero == scrollView.frame.size)
+            updatePageControl(shouldUpdateCurrentPage: collectionViewSize.map { $0 == scrollView.frame.size} ?? false)
         }
     }
     


### PR DESCRIPTION
iOS - Universal App - carouselView always goes back to Optus default landing view when changed orientation	
. merge to wrong branch, have to merge again