### PR TITLE
Renamed topViewController to firstViewController 

### DIFF
--- a/BFWControls/Modules/Transition/View/UIViewController+Dismiss.swift
+++ b/BFWControls/Modules/Transition/View/UIViewController+Dismiss.swift
@@ -24,13 +24,13 @@ public extension UIViewController {
         }
     }
     
-    public var topViewController: UIViewController {
+    public var firstViewController: UIViewController {
         return (self as? UINavigationController)?.viewControllers.first ?? self
     }
     
     public var readiedForPush: UIViewController {
         removeDismiss()
-        return topViewController
+        return firstViewController
     }
     
 }


### PR DESCRIPTION
The returned view controller is the first controller on the navigation stack, not the top one.